### PR TITLE
chore(deps): add quick-lru dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@netlify/database": "^1.0.0",
     "@sentry/node": "^10.53.1",
     "@supabase/supabase-js": "^2.105.4",
-    "openai": "^6.37.0"
+    "openai": "^6.37.0",
+    "quick-lru": "^7.3.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds `quick-lru` as an explicit root dependency for the pnpm-managed workspace.

## Change

- Updates root `package.json`
- Adds `quick-lru` as a direct dependency

## Follow-up before merge

The lockfile should be regenerated with pnpm before this PR is merged, because this connector can update GitHub files but cannot execute package-manager installs.

Validation recommended:

- pnpm install
- pnpm install --frozen-lockfile
- pnpm run typecheck
- pnpm run test
- pnpm run build

## Risk check

- Do not add package-lock.json
- Do not hand-edit pnpm lockfile integrity data
- Keep the change dependency-only

Closes #2236